### PR TITLE
switch to simple express to serve react dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "webpack",
     "watch": "webpack -w",
-    "serve": "live-server dist"
+    "serve": "nodemon server.js"
   },
   "author": "",
   "license": "ISC",
@@ -18,6 +18,7 @@
     "axios": "^0.21.4",
     "babel-loader": "^8.2.2",
     "bootstrap": "^5.1.0",
+    "express": "^4.17.1",
     "html-webpack-plugin": "^5.3.2",
     "live-server": "^1.2.1",
     "react": "^17.0.2",
@@ -34,6 +35,7 @@
     "webpack-cli": "^4.8.0"
   },
   "devDependencies": {
-    "css-loader": "^6.5.0"
+    "css-loader": "^6.5.0",
+    "nodemon": "^2.0.14"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,22 @@
+const express = require('express')
+const app = express()
+const port = 8080
+
+app.get("/newAccount", (req, res) => {
+    res.redirect('/')
+})
+app.get("/users", (req, res) => {
+    res.redirect('/')
+})
+app.get("/user", (req, res) => {
+    res.redirect('/')
+})
+app.get("/remove", (req, res) => {
+    res.redirect('/')
+})
+
+app.use('/', express.static('dist'))
+
+app.listen(port, () => {
+  console.log(`Express server: React being served from dist folder at http://localhost:${port}`)
+})


### PR DESCRIPTION
use express to serve instead of live-server. pages will now reload better. On reload will load to home page instead of 404 error. same command to run server. 